### PR TITLE
fix kwalitee errors

### DIFF
--- a/lib/Redis/LeaderBoardMulti/Member.pm
+++ b/lib/Redis/LeaderBoardMulti/Member.pm
@@ -1,5 +1,9 @@
 package Redis::LeaderBoardMulti::Member;
 
+use 5.008005;
+use strict;
+use warnings;
+
 sub new {
     my ($class, %args) = @_;
     my $self = bless {


### PR DESCRIPTION
http://cpants.cpanauthors.org/release/SHOGO/Redis-LeaderBoardMulti-0.01

> use_strict
> Add 'use strict' (or its equivalents) to all modules, or convince us that your favorite module is well-known enough and people can easily see the modules are strictly written.
>
> Error: Redis::LeaderBoardMulti::Member
>
> use_warnings
> Add 'use warnings' (or its equivalents) to all modules (this will require perl > 5.6), or convince us that your favorite module is well-known enough and people can easily see the modules warn when something bad happens.
>
> Error: Redis::LeaderBoardMulti::Member